### PR TITLE
User sync fixes for 7 25 0

### DIFF
--- a/modules/insticatorBidAdapter.js
+++ b/modules/insticatorBidAdapter.js
@@ -22,15 +22,15 @@ config.setDefaults({
 });
 
 function getUserId() {
+  uid = localStorage.getItem(USER_ID_KEY);
+  if (uid && isUserIdValid(uid)) {
+    return uid;
+  }
+
   let uid = storage.getCookie(USER_ID_KEY);
   if (uid && isUserIdValid(uid)) {
     const expireIn = new Date(Date.now() + USER_ID_COOKIE_EXP).toUTCString();
     storage.setCookie(USER_ID_KEY, uid, expireIn);
-    return uid;
-  }
-
-  uid = localStorage.getItem(USER_ID_KEY);
-  if (uid && isUserIdValid(uid)) {
     return uid;
   }
 
@@ -44,14 +44,14 @@ function isUserIdValid(uid) {
 function generateUserId() {
   const uid = generateUUID();
 
-  if (isCookieEnabled()) {
-    const expireIn = new Date(Date.now() + USER_ID_COOKIE_EXP).toUTCString();
-    storage.setCookie(USER_ID_KEY, uid, expireIn);
+  if (isLocalStoreEnabled()) {
+    localStorage.setItem(USER_ID_KEY, uid);
     return uid;
   }
 
-  if (isLocalStoreEnabled()) {
-    localStorage.setItem(USER_ID_KEY, uid);
+  if (isCookieEnabled()) {
+    const expireIn = new Date(Date.now() + USER_ID_COOKIE_EXP).toUTCString();
+    storage.setCookie(USER_ID_KEY, uid, expireIn);
   }
 
   return uid;

--- a/modules/insticatorBidAdapter.js
+++ b/modules/insticatorBidAdapter.js
@@ -22,12 +22,12 @@ config.setDefaults({
 });
 
 function getUserId() {
-  uid = localStorage.getItem(USER_ID_KEY);
+  let uid = localStorage.getItem(USER_ID_KEY);
   if (uid && isUserIdValid(uid)) {
     return uid;
   }
 
-  let uid = storage.getCookie(USER_ID_KEY);
+  uid = storage.getCookie(USER_ID_KEY);
   if (uid && isUserIdValid(uid)) {
     const expireIn = new Date(Date.now() + USER_ID_COOKIE_EXP).toUTCString();
     storage.setCookie(USER_ID_KEY, uid, expireIn);

--- a/modules/insticatorBidAdapter.js
+++ b/modules/insticatorBidAdapter.js
@@ -168,7 +168,7 @@ function buildUser(bid) {
   const gender = deepAccess(bid, 'params.user.gender')
 
   return {
-    buyeruid: userId,
+    id: userId,
     yob,
     gender,
   };

--- a/modules/insticatorBidAdapter.js
+++ b/modules/insticatorBidAdapter.js
@@ -168,7 +168,7 @@ function buildUser(bid) {
   const gender = deepAccess(bid, 'params.user.gender')
 
   return {
-    id: userId,
+    buyeruid: userId,
     yob,
     gender,
   };

--- a/modules/insticatorBidAdapter.js
+++ b/modules/insticatorBidAdapter.js
@@ -8,7 +8,7 @@ import {find} from '../src/polyfill.js';
 const BIDDER_CODE = 'insticator';
 const ENDPOINT = 'https://ex.ingage.tech/v1/openrtb'; // production endpoint
 const USER_ID_KEY = 'hb_insticator_uid';
-const USER_ID_COOKIE_EXP = 2592000000; // 30 days
+const USER_ID_COOKIE_EXP = 7776000000; // 90 days
 const BID_TTL = 300; // 5 minutes
 const GVLID = 910;
 
@@ -22,30 +22,74 @@ config.setDefaults({
 });
 
 function getUserId() {
-  let uid;
-
-  if (storage.localStorageIsEnabled()) {
-    uid = localStorage.getItem(USER_ID_KEY);
-  } else {
-    uid = storage.getCookie(USER_ID_KEY);
+  let uid = storage.getCookie(USER_ID_KEY);
+  if (uid && isUserIdValid(uid)) {
+    const expireIn = new Date(Date.now() + USER_ID_COOKIE_EXP).toUTCString();
+    storage.setCookie(USER_ID_KEY, uid, expireIn);
+    return uid;
   }
 
-  if (uid && uid.length !== 36) {
-    uid = undefined;
+  uid = localStorage.getItem(USER_ID_KEY);
+  if (uid && isUserIdValid(uid)) {
+    return uid;
+  }
+
+  return generateUserId()
+}
+
+function isUserIdValid(uid) {
+  return uid && uid.length === 36;
+}
+
+function generateUserId() {
+  const uid = generateUUID();
+
+  if (isCookieEnabled()) {
+    const expireIn = new Date(Date.now() + USER_ID_COOKIE_EXP).toUTCString();
+    storage.setCookie(USER_ID_KEY, uid, expireIn);
+    return uid;
+  }
+
+  if (isLocalStoreEnabled()) {
+    localStorage.setItem(USER_ID_KEY, uid);
   }
 
   return uid;
 }
 
-function setUserId(userId) {
-  if (storage.localStorageIsEnabled()) {
-    localStorage.setItem(USER_ID_KEY, userId);
+function isLocalStoreEnabled() {
+  let enabled = false;
+
+  try {
+    localStorage.setItem('prebid.localStoreTest', 'true');
+    enabled = Boolean(localStorage.getItem('prebid.localStoreTest'));
+  } catch (err) {
+    return false
+  } finally {
+    if (enabled) {
+      localStorage.removeItem('insticator.prebid.localStoreTest');
+    }
   }
 
-  if (storage.cookiesAreEnabled()) {
-    const expires = new Date(Date.now() + USER_ID_COOKIE_EXP).toUTCString();
-    storage.setCookie(USER_ID_KEY, userId, expires);
+  return enabled;
+}
+
+function isCookieEnabled() {
+  let enabled = false;
+
+  try {
+    const expireIn = new Date(Date.now() + USER_ID_COOKIE_EXP).toUTCString();
+    storage.setCookie('insticator.prebid.cookieTest', 'true', expireIn);
+    enabled = Boolean(storage.getCookie('insticator.prebid.cookieTest'));
+  } catch (err) {
+    return false;
+  } finally {
+    if (enabled) {
+      storage.setCookie('insticator.prebid.cookieTest', 'true', new Date(Date.now()).toUTCString());
+    }
   }
+
+  return enabled;
 }
 
 function buildImpression(bidRequest) {
@@ -95,10 +139,7 @@ function buildDevice() {
     w: window.innerWidth,
     h: window.innerHeight,
     js: true,
-    ext: {
-      localStorage: storage.localStorageIsEnabled(),
-      cookies: storage.cookiesAreEnabled(),
-    },
+    ext: {},
   };
 
   if (typeof deviceConfig === 'object') {
@@ -122,11 +163,9 @@ function buildRegs(bidderRequest) {
 }
 
 function buildUser(bid) {
-  const userId = getUserId() || generateUUID();
+  const userId = getUserId();
   const yob = deepAccess(bid, 'params.user.yob')
   const gender = deepAccess(bid, 'params.user.gender')
-
-  setUserId(userId);
 
   return {
     id: userId,

--- a/test/spec/modules/insticatorBidAdapter_spec.js
+++ b/test/spec/modules/insticatorBidAdapter_spec.js
@@ -335,7 +335,7 @@ describe('InsticatorBidAdapter', function () {
       const requests = spec.buildRequests([bidRequest], bidderRequest);
       const data = JSON.parse(requests[0].data);
 
-      expect(data.user.id).to.equal(USER_ID_STUBBED); 
+      expect(data.user.id).to.equal(USER_ID_STUBBED);
     });
     it('should return empty regs object if no gdprConsent is passed', function () {
       const requests = spec.buildRequests([bidRequest], { ...bidderRequest, ...{ gdprConsent: false } });

--- a/test/spec/modules/insticatorBidAdapter_spec.js
+++ b/test/spec/modules/insticatorBidAdapter_spec.js
@@ -335,7 +335,7 @@ describe('InsticatorBidAdapter', function () {
       const requests = spec.buildRequests([bidRequest], bidderRequest);
       const data = JSON.parse(requests[0].data);
 
-      expect(data.user.id).to.equal(USER_ID_STUBBED);
+      expect(data.user.buyeruid).to.equal(USER_ID_STUBBED);
     });
     it('should return empty regs object if no gdprConsent is passed', function () {
       const requests = spec.buildRequests([bidRequest], { ...bidderRequest, ...{ gdprConsent: false } });

--- a/test/spec/modules/insticatorBidAdapter_spec.js
+++ b/test/spec/modules/insticatorBidAdapter_spec.js
@@ -335,7 +335,7 @@ describe('InsticatorBidAdapter', function () {
       const requests = spec.buildRequests([bidRequest], bidderRequest);
       const data = JSON.parse(requests[0].data);
 
-      expect(data.user.buyeruid).to.equal(USER_ID_STUBBED);
+      expect(data.user.id).to.equal(USER_ID_STUBBED);
     });
     it('should return empty regs object if no gdprConsent is passed', function () {
       const requests = spec.buildRequests([bidRequest], { ...bidderRequest, ...{ gdprConsent: false } });

--- a/test/spec/modules/insticatorBidAdapter_spec.js
+++ b/test/spec/modules/insticatorBidAdapter_spec.js
@@ -270,8 +270,6 @@ describe('InsticatorBidAdapter', function () {
       expect(data.device.h).to.equal(window.innerHeight);
       expect(data.device.js).to.equal(true);
       expect(data.device.ext).to.be.an('object');
-      expect(data.device.ext.localStorage).to.equal(true);
-      expect(data.device.ext.cookies).to.equal(false);
       expect(data.regs).to.be.an('object');
       expect(data.regs.ext.gdpr).to.equal(1);
       expect(data.regs.ext.gdprConsentString).to.equal(bidderRequest.gdprConsent.consentString);

--- a/test/spec/modules/insticatorBidAdapter_spec.js
+++ b/test/spec/modules/insticatorBidAdapter_spec.js
@@ -335,7 +335,7 @@ describe('InsticatorBidAdapter', function () {
       const requests = spec.buildRequests([bidRequest], bidderRequest);
       const data = JSON.parse(requests[0].data);
 
-      expect(data.user.id).to.equal(USER_ID_STUBBED);
+      expect(data.user.id).to.equal(USER_ID_STUBBED); 
     });
     it('should return empty regs object if no gdprConsent is passed', function () {
       const requests = spec.buildRequests([bidRequest], { ...bidderRequest, ...{ gdprConsent: false } });


### PR DESCRIPTION
User sync fix - prioritize local store over cookie to store the user ID, so that the same value can be shared among tabs.